### PR TITLE
feat: Import bufetu z XLSX FiskalPRO (nahrazuje CSV)

### DIFF
--- a/apps/bufet/fiskalpro_parser.py
+++ b/apps/bufet/fiskalpro_parser.py
@@ -79,12 +79,14 @@ def parse_fiskalpro_xlsx(xlsx_file) -> list[dict]:
     try:
         header = next(rows)
     except StopIteration:
-        raise ValueError("XLSX je prázdný.")
+        wb.close()
+        raise ValueError("XLSX je prázdný.") from None
 
     col = {str(name).strip(): idx for idx, name in enumerate(header) if name is not None}
     missing = XLSX_REQUIRED_COLUMNS - set(col)
     if missing:
-        raise ValueError(f"XLSX neobsahuje očekávané sloupce: {', '.join(sorted(missing))}")
+        wb.close()
+        raise ValueError(f"XLSX neobsahuje očekávané sloupce: {', '.join(sorted(missing))}") from None
 
     def cell(row, name, default=''):
         idx = col.get(name)

--- a/apps/bufet/fiskalpro_parser.py
+++ b/apps/bufet/fiskalpro_parser.py
@@ -1,98 +1,121 @@
 """
-Parser pro CSV přehledy prodeje z pokladního systému FiskalPRO.
+Parser přehledů prodeje z pokladního systému FiskalPRO.
+
+Formát XLSX "Položky dokladů – kumulované …": export bez provozovny,
+s typem dokladu (prodej / storno) a DPH na řádek; agregace po názvu.
 """
-import csv
 import io
 import re
 from decimal import Decimal, InvalidOperation
 from datetime import date
 
 
-FILENAME_DATE_RE = re.compile(r'(\d{8})-\d{6}')
+# "…kumulované 2026-07-05 11-44-41.xlsx" (YYYY-MM-DD HH-MM-SS)
+FILENAME_DATE_RE = re.compile(r'(\d{4})-(\d{2})-(\d{2})[ _]\d{2}-\d{2}-\d{2}')
+
+# Sloupce XLSX exportu "Položky dokladů – kumulované"
+XLSX_REQUIRED_COLUMNS = {'Typ', 'Artikl', 'Název', 'Množství', 'Celkem s DPH'}
 
 
 def parse_export_date(filename: str) -> date | None:
-    """Extrahuje datum exportu z názvu souboru (formát YYYYMMDD-HHMMSS)."""
-    m = FILENAME_DATE_RE.search(filename)
+    """Extrahuje datum exportu z názvu souboru."""
+    m = FILENAME_DATE_RE.search(filename or '')
     if not m:
         return None
     try:
-        return date(int(m.group(1)[:4]), int(m.group(1)[4:6]), int(m.group(1)[6:8]))
+        return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
     except ValueError:
         return None
 
 
-def _parse_decimal(value: str) -> Decimal:
-    """Převede číslo s desetinnou čárkou na Decimal."""
+def _to_decimal(value) -> Decimal:
+    """Bezpečně převede číselnou/textovou hodnotu buňky na Decimal."""
+    if value is None:
+        return Decimal('0')
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
     try:
-        return Decimal(value.strip().replace(',', '.') or '0')
+        return Decimal(str(value).strip().replace(',', '.') or '0')
     except InvalidOperation:
         return Decimal('0')
 
 
-def parse_fiskalpro_csv(csv_file) -> list[dict]:
+def parse_fiskalpro_xlsx(xlsx_file) -> list[dict]:
     """
-    Parsuje CSV přehled prodeje z FiskalPRO a agreguje množství přes všechny provozovny.
+    Parsuje XLSX export "Položky dokladů – kumulované" z FiskalPRO.
 
-    Args:
-        csv_file: file-like objekt nebo bytes s CSV daty
+    - Neobsahuje provozovnu (establishments zůstává prázdné).
+    - Obsahuje typ dokladu (0 - prodej, 1 - prodej návrat/storno, platba …).
+      Platební řádky se ignorují; storno má záporné množství a odečítá se.
+    - Artiklové číslo NENÍ jednoznačné (jeden kód = více produktů), proto
+      agregujeme podle názvu položky.
 
     Returns:
-        list slovníků s agregovanými položkami:
-            - article_code: kód artiklíku
-            - barcode: EAN kód (může být prázdný)
-            - name: název položky
-            - group: skupina/kategorie z pokladny
-            - quantity: celkové prodané množství (přes všechny provozovny)
-            - unit: měrná jednotka
-            - total_price_with_vat: celková tržba vč. DPH
-            - total_price_without_vat: celková tržba bez DPH
-            - establishments: seznam provozoven, kde bylo prodáno
+        list slovníků s klíči: article_code, barcode, name, group, quantity,
+        unit, total_price_with_vat, total_price_without_vat, establishments.
+        Vrací jen položky s kladným čistým prodaným množstvím (po odečtení storna).
 
     Raises:
-        ValueError: pokud soubor nelze načíst nebo neobsahuje očekávané sloupce
+        ValueError: pokud sešit nelze načíst nebo chybí očekávané sloupce.
     """
-    if isinstance(csv_file, (bytes, bytearray)):
-        raw = csv_file
-    else:
-        raw = csv_file.read()
+    try:
+        import openpyxl
+    except ImportError as e:
+        raise ValueError("Knihovna openpyxl není nainstalována.") from e
 
-    # Detekce kódování: FiskalPRO exportuje Windows-1250
-    for encoding in ('cp1250', 'utf-8-sig', 'utf-8'):
-        try:
-            text = raw.decode(encoding)
-            break
-        except UnicodeDecodeError:
-            continue
-    else:
-        raise ValueError("Nepodporované kódování souboru. Očekáváno Windows-1250 nebo UTF-8.")
+    if isinstance(xlsx_file, (bytes, bytearray)):
+        xlsx_file = io.BytesIO(xlsx_file)
 
-    reader = csv.DictReader(io.StringIO(text), delimiter=';')
+    try:
+        wb = openpyxl.load_workbook(xlsx_file, read_only=True, data_only=True)
+    except Exception as e:
+        raise ValueError(f"Soubor XLSX nelze načíst: {e}") from e
 
-    required_columns = {'Artikl', 'Název', 'Množství', 'Cena celkem s DPH'}
-    if not required_columns.issubset(set(reader.fieldnames or [])):
-        missing = required_columns - set(reader.fieldnames or [])
-        raise ValueError(f"CSV neobsahuje očekávané sloupce: {', '.join(missing)}")
+    ws = wb.active
+    rows = ws.iter_rows(values_only=True)
 
-    # Agregace po artiklíku
+    try:
+        header = next(rows)
+    except StopIteration:
+        raise ValueError("XLSX je prázdný.")
+
+    col = {str(name).strip(): idx for idx, name in enumerate(header) if name is not None}
+    missing = XLSX_REQUIRED_COLUMNS - set(col)
+    if missing:
+        raise ValueError(f"XLSX neobsahuje očekávané sloupce: {', '.join(sorted(missing))}")
+
+    def cell(row, name, default=''):
+        idx = col.get(name)
+        if idx is None or idx >= len(row) or row[idx] is None:
+            return default
+        return row[idx]
+
     aggregated: dict[str, dict] = {}
 
-    for row in reader:
-        code = row['Artikl'].strip()
-        if not code:
+    for row in rows:
+        typ = str(cell(row, 'Typ', '')).strip()
+        # Bereme jen řádky prodeje (a jeho storno); platby a jiné doklady ignorujeme
+        if 'prodej' not in typ.lower():
             continue
 
-        qty = _parse_decimal(row.get('Množství', '0'))
-        price_with_vat = _parse_decimal(row.get('Cena celkem s DPH', '0'))
-        price_without_vat = _parse_decimal(row.get('Cena celkem', '0'))
-        barcode = row.get('Čárový kód', '').strip()
-        name = row.get('Název', '').strip()
-        group = row.get('Skupina', '').strip()
-        unit = row.get('MJ', 'ks').strip()
-        establishment = row.get('Název provozovny', '').strip()
+        name = str(cell(row, 'Název', '')).strip()
+        if not name:
+            continue
 
-        if code not in aggregated:
-            aggregated[code] = {
+        qty = _to_decimal(cell(row, 'Množství', 0))
+        price_with_vat = _to_decimal(cell(row, 'Celkem s DPH', 0))
+        price_without_vat = _to_decimal(cell(row, 'Celkem', 0))
+        code = str(cell(row, 'Artikl', '')).strip()
+        barcode = str(cell(row, 'Čárový kód', '')).strip()
+        group = str(cell(row, 'Skupina', '')).strip()
+        unit = str(cell(row, 'MJ', '')).strip() or 'ks'
+
+        # Agregujeme podle názvu – artiklové číslo není jednoznačné
+        entry = aggregated.get(name)
+        if entry is None:
+            entry = aggregated[name] = {
                 'article_code': code,
                 'barcode': barcode,
                 'name': name,
@@ -104,18 +127,22 @@ def parse_fiskalpro_csv(csv_file) -> list[dict]:
                 'establishments': [],
             }
 
-        entry = aggregated[code]
         entry['quantity'] += qty
         entry['total_price_with_vat'] += price_with_vat
         entry['total_price_without_vat'] += price_without_vat
-
-        # Upřednostňujeme záznam s EAN a skupinou
         if barcode and not entry['barcode']:
             entry['barcode'] = barcode
         if group and not entry['group']:
             entry['group'] = group
 
-        if establishment and establishment not in entry['establishments']:
-            entry['establishments'].append(establishment)
+    wb.close()
 
-    return list(aggregated.values())
+    # Jen položky s kladným čistým prodejem (storno mohlo prodej vynulovat)
+    return [e for e in aggregated.values() if e['quantity'] > 0]
+
+
+def parse_bufet_file(uploaded_file, filename: str) -> list[dict]:
+    """Načte položky prodeje z nahraného souboru (podporován XLSX z FiskalPRO)."""
+    if not (filename or '').lower().endswith('.xlsx'):
+        raise ValueError("Nepodporovaný formát souboru. Nahrajte XLSX z FiskalPRO.")
+    return parse_fiskalpro_xlsx(uploaded_file)

--- a/apps/bufet/tests.py
+++ b/apps/bufet/tests.py
@@ -1,0 +1,91 @@
+import io
+from datetime import date
+from decimal import Decimal
+
+import openpyxl
+from django.test import TestCase
+
+from apps.bufet.fiskalpro_parser import (
+    parse_bufet_file,
+    parse_export_date,
+    parse_fiskalpro_xlsx,
+)
+
+
+def _make_xlsx(rows):
+    """Sestaví XLSX v paměti s hlavičkou exportu 'Položky dokladů'."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(['Typ', 'Artikl', 'Čárový kód', 'Název', 'Skupina', 'DPH',
+               'Množství', 'MJ', 'Celkem', 'Daň', 'Celkem s DPH'])
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+class BufetXlsxParserTest(TestCase):
+    def test_export_date_from_iso_filename(self):
+        d = parse_export_date('Položky dokladů - kumulované 2026-07-05 11-44-41.xlsx')
+        self.assertEqual(d, date(2026, 7, 5))
+
+    def test_aggregates_by_name_not_article_code(self):
+        # Stejný artiklový kód '1', dva různé produkty -> nesmí se sloučit
+        xlsx = _make_xlsx([
+            ['0 - prodej', '1', '', 'Pegas Almond', '1 - Nanuky', '12%', 10, 'ks', 100, 12, 112],
+            ['0 - prodej', '1', '', 'Kinder Bueno', '1 - Nanuky', '21%', 5, 'ks', 50, 10, 60],
+        ])
+        items = {i['name']: i for i in parse_fiskalpro_xlsx(xlsx)}
+        self.assertEqual(set(items), {'Pegas Almond', 'Kinder Bueno'})
+        self.assertEqual(items['Pegas Almond']['quantity'], Decimal('10'))
+        self.assertEqual(items['Kinder Bueno']['quantity'], Decimal('5'))
+
+    def test_storno_subtracts(self):
+        xlsx = _make_xlsx([
+            ['0 - prodej', '5', '', 'Kofola', '', '12%', 20, 'ks', 200, 24, 224],
+            ['1 - prodej návrat/storno', '5', '', 'Kofola', '', '12%', -3, 'ks', -30, -3.6, -33.6],
+        ])
+        items = parse_fiskalpro_xlsx(xlsx)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]['quantity'], Decimal('17'))
+
+    def test_fully_returned_item_dropped(self):
+        xlsx = _make_xlsx([
+            ['0 - prodej', '5', '', 'Kofola', '', '12%', 3, 'ks', 30, 3.6, 33.6],
+            ['1 - prodej návrat/storno', '5', '', 'Kofola', '', '12%', -3, 'ks', -30, -3.6, -33.6],
+        ])
+        self.assertEqual(parse_fiskalpro_xlsx(xlsx), [])
+
+    def test_non_sale_rows_ignored(self):
+        xlsx = _make_xlsx([
+            ['0 - prodej', '5', '', 'Kofola', '', '12%', 4, 'ks', 40, 4.8, 44.8],
+            ['107 - platba (karta/QR kód)', '', '', 'Platba', '', '0%', 1, '', 0, 0, 0],
+        ])
+        items = parse_fiskalpro_xlsx(xlsx)
+        self.assertEqual([i['name'] for i in items], ['Kofola'])
+
+    def test_empty_unit_defaults_to_ks(self):
+        xlsx = _make_xlsx([
+            ['0 - prodej', '5', '', 'Kofola', '', '12%', 4, None, 40, 4.8, 44.8],
+        ])
+        self.assertEqual(parse_fiskalpro_xlsx(xlsx)[0]['unit'], 'ks')
+
+    def test_missing_columns_raise(self):
+        wb = openpyxl.Workbook()
+        wb.active.append(['Typ', 'Artikl', 'Název'])  # chybí Množství, Celkem s DPH
+        buf = io.BytesIO(); wb.save(buf); buf.seek(0)
+        with self.assertRaises(ValueError):
+            parse_fiskalpro_xlsx(buf)
+
+    def test_dispatch_by_extension(self):
+        xlsx = _make_xlsx([
+            ['0 - prodej', '5', '', 'Kofola', '', '12%', 4, 'ks', 40, 4.8, 44.8],
+        ])
+        items = parse_bufet_file(xlsx, 'export.xlsx')
+        self.assertEqual(items[0]['name'], 'Kofola')
+
+    def test_dispatch_unknown_extension(self):
+        with self.assertRaises(ValueError):
+            parse_bufet_file(io.BytesIO(b'x'), 'data.txt')

--- a/apps/bufet/tests.py
+++ b/apps/bufet/tests.py
@@ -75,7 +75,9 @@ class BufetXlsxParserTest(TestCase):
     def test_missing_columns_raise(self):
         wb = openpyxl.Workbook()
         wb.active.append(['Typ', 'Artikl', 'Název'])  # chybí Množství, Celkem s DPH
-        buf = io.BytesIO(); wb.save(buf); buf.seek(0)
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
         with self.assertRaises(ValueError):
             parse_fiskalpro_xlsx(buf)
 

--- a/apps/bufet/views.py
+++ b/apps/bufet/views.py
@@ -14,7 +14,7 @@ from apps.core.models import Ingredient
 from apps.core.views import user_can_access_canteen
 from apps.inventory.models import StockWriteOff, StockWriteOffItem
 
-from .fiskalpro_parser import parse_export_date, parse_fiskalpro_csv
+from .fiskalpro_parser import parse_bufet_file, parse_export_date
 from .models import BufetImport, BufetImportItem
 
 NUMERIC_FIELDS = ('quantity', 'total_price_with_vat', 'total_price_without_vat')
@@ -242,16 +242,16 @@ def bufet_upload_step1(request):
     warehouses = _get_user_warehouses(request.user)
 
     if request.method == 'POST':
-        csv_file = request.FILES.get('csv_file')
+        upload = request.FILES.get('csv_file')
         warehouse_id = request.POST.get('warehouse')
 
-        if not csv_file or not warehouse_id:
-            messages.error(request, 'Musíte vybrat CSV soubor a sklad.')
+        if not upload or not warehouse_id:
+            messages.error(request, 'Musíte vybrat soubor (CSV/XLSX) a sklad.')
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
         try:
             warehouse = Warehouse.objects.get(id=warehouse_id)
-        except Warehouse.DoesNotExist:
+        except (Warehouse.DoesNotExist, ValueError):
             messages.error(request, 'Vybraný sklad neexistuje.')
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
@@ -260,20 +260,24 @@ def bufet_upload_step1(request):
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
         try:
-            items = parse_fiskalpro_csv(csv_file)
+            items = parse_bufet_file(upload, upload.name)
         except ValueError as e:
-            messages.error(request, f'Chyba při načítání CSV: {e}')
+            messages.error(request, f'Chyba při načítání souboru: {e}')
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
-        export_date = parse_export_date(csv_file.name)
+        if not items:
+            messages.error(request, 'Soubor neobsahuje žádné prodané položky.')
+            return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
+
+        export_date = parse_export_date(upload.name)
 
         # Uložení do session
         request.session['bufet_warehouse_id'] = warehouse_id
-        request.session['bufet_filename'] = csv_file.name
+        request.session['bufet_filename'] = upload.name
         request.session['bufet_export_date'] = export_date.isoformat() if export_date else None
         request.session['bufet_items'] = [_serialize_bufet_item(it) for it in items]
 
-        messages.success(request, f'CSV načteno: {len(items)} unikátních artiklů.')
+        messages.success(request, f'Soubor načten: {len(items)} položek.')
         return redirect('bufet:upload_step2')
 
     return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})

--- a/apps/bufet/views.py
+++ b/apps/bufet/views.py
@@ -246,7 +246,7 @@ def bufet_upload_step1(request):
         warehouse_id = request.POST.get('warehouse')
 
         if not upload or not warehouse_id:
-            messages.error(request, 'Musíte vybrat soubor (CSV/XLSX) a sklad.')
+            messages.error(request, 'Musíte vybrat soubor XLSX a sklad.')
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
         try:

--- a/templates/bufet/bufet_upload_step1.html
+++ b/templates/bufet/bufet_upload_step1.html
@@ -30,11 +30,11 @@
           {% csrf_token %}
 
           <div class="mb-4">
-            <label class="form-label fw-bold">CSV soubor z FiskalPRO</label>
-            <input type="file" name="csv_file" accept=".csv" required class="form-control">
+            <label class="form-label fw-bold">Soubor XLSX z FiskalPRO</label>
+            <input type="file" name="csv_file" accept=".xlsx" required class="form-control">
             <div class="form-text">
-              Přehled prodeje generovaný z FiskalPRO (formát: <em>Přehled prodeje YYYYMMDD-HHMMSS.csv</em>).<br>
-              Kódování Windows-1250, oddělovač středník.
+              Export <em>Položky dokladů – kumulované … .xlsx</em> z FiskalPRO
+              (agregace po názvu; storno se odečítá).
             </div>
           </div>
 


### PR DESCRIPTION
Přechod na novější export "Položky dokladů – kumulované *.xlsx":
- Agregace po názvu položky (artiklový kód není jednoznačný – jeden kód mapuje na více produktů).
- Zohlednění typu dokladu: berou se řádky prodeje a jeho storna (záporné množství se odečítá), platební řádky se ignorují.
- Vrací jen položky s kladným čistým prodejem.
- Datum exportu z názvu souboru (YYYY-MM-DD HH-MM-SS).

CSV import odstraněn (parse_fiskalpro_csv a CSV helpery), upload i formulář nově přijímají pouze XLSX. Přidány testy parseru (9).

## Souhrn od Sourcery

Přepnutí importu bufetu z FiskalPRO CSV reportů na novější kumulativní XLSX export a úprava průběhu nahrávání dle toho.

Nové funkce:
- Podpora importu prodejů bufetu z kumulativního XLSX exportu FiskalPRO („Položky dokladů – kumulované“) místo CSV.
- Odvození data exportu z ISO‑podobných časových razítek v názvech XLSX souborů a agregace prodejů podle názvu položky včetně zohlednění storen.

Opravy chyb:
- Vyloučení řádků, které nepředstavují prodej/platbu, a položek s nulovým nebo záporným čistým množstvím z importovaných položek bufetu, aby se zabránilo nesprávným skladovým údajům.

Vylepšení:
- Zjednodušení práce se soubory bufetu za jednotným vstupním bodem parseru, který ověřuje příponu souboru a formát.
- Vylepšení uživatelsky viditelných zpráv a textu formuláře pro nahrávání tak, aby odrážely podporu pouze XLSX a poskytovaly srozumitelnější hlášení chyb.

Testy:
- Přidání unit testů pokrývajících parsování XLSX, agregaci podle názvu, odečítání storen, filtrování řádků mimo prodej, výchozí jednotky, validaci povinných sloupců a směrování parseru podle přípony souboru.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch buffet import from FiskalPRO CSV reports to the newer cumulative XLSX export format and adjust upload flow accordingly.

New Features:
- Support importing buffet sales from FiskalPRO cumulative XLSX export ('Položky dokladů – kumulované') instead of CSV.
- Derive export date from ISO-like timestamps in XLSX filenames and aggregate sales by item name with storno handling.

Bug Fixes:
- Exclude non-sale/payment rows and items with zero or negative net quantity from imported buffet items to avoid incorrect stock data.

Enhancements:
- Simplify buffet file handling behind a unified parser entrypoint that validates file extension and format.
- Improve user-facing messages and upload form text to reflect XLSX-only support and clearer error reporting.

Tests:
- Add unit tests covering XLSX parsing, aggregation by name, storno subtraction, filtering of non-sale rows, default units, required-column validation, and parser dispatch by file extension.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File upload now supports FiskalPRO **XLSX** exports instead of CSV.
  * The upload flow now handles item aggregation, cancellations, and date extraction from the uploaded filename.

* **Bug Fixes**
  * Improved parsing of sold items, including dropping fully returned items and ignoring non-sale rows.
  * Added clearer validation and error messages when required data is missing or no sold items are found.

* **Tests**
  * Added coverage for XLSX parsing, file-type dispatch, missing columns, and quantity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->