### PR TITLE
feat: Přepracování zadávání skutečných množství ve výdejce

### DIFF
--- a/apps/production/tests/test_meal_replacement.py
+++ b/apps/production/tests/test_meal_replacement.py
@@ -75,8 +75,10 @@ class MealReplacementTest(TestCase):
         return f'/production/vydejky/{self.document.id}/edit/'
 
     def _existing_qty_fields(self):
+        # Nová UX: pole skutečného množství jsou defaultně prázdná. Prázdné =
+        # beze změny (položka zůstane PENDING), takže záměnu jídla nezablokují.
         return {
-            f'quantity_actual_item_{item.id}': str(item.quantity_planned)
+            f'quantity_actual_item_{item.id}': ''
             for item in PickingList.objects.filter(document=self.document)
         }
 

--- a/apps/production/tests/test_picking_edit_actuals.py
+++ b/apps/production/tests/test_picking_edit_actuals.py
@@ -115,6 +115,20 @@ class PickingEditActualsTest(TestCase):
         self.assertEqual(self.stock.quantity, Decimal('100.000'))
         self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
 
+    def test_zero_quantity_is_rejected(self):
+        """0 není platné vydané množství – položka zůstane PENDING."""
+        response = self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '0',
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, PickingList.Status.PENDING)
+        self.assertIsNone(self.item.quantity_actual)
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('100.000'))
+        self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
+
     def test_missing_field_leaves_item_unchanged(self):
         """Pole vůbec neodeslané (jiná akce) → položka beze změny."""
         response = self.client.post(self._url(), data={'cook': ''})
@@ -125,7 +139,6 @@ class PickingEditActualsTest(TestCase):
         self.assertIsNone(self.item.quantity_actual)
         self.stock.refresh_from_db()
         self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
-
     def test_delete_item_removes_and_unblocks(self):
         """Koš → smaže položku a uvolní blokaci na skladu."""
         item_id = self.item.id

--- a/apps/production/tests/test_picking_edit_actuals.py
+++ b/apps/production/tests/test_picking_edit_actuals.py
@@ -1,0 +1,158 @@
+"""Testy nového workflow zadávání skutečně vydaných množství ve výdejce.
+
+Nová UX (větev výdejky-rework):
+- pole skutečného množství jsou defaultně prázdná,
+- vyplněné množství = vydat (COMPLETED + odečet ze skladu),
+- prázdné pole = beze změny (položka zůstane PENDING, blokace drží),
+- koš odebere surovinu z výdejky a uvolní blokaci na skladu.
+"""
+from decimal import Decimal
+from datetime import date
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from apps.canteens.models import Canteen, Warehouse
+from apps.core.models import Ingredient, Recipe, RecipeIngredient
+from apps.inventory.models import StockItem
+from apps.production.models import (
+    ProductionOrder, PickingList, MenuPlan,
+    ProductionOrderPortionVariant, PickingListDocument,
+)
+
+
+class PickingEditActualsTest(TestCase):
+    def setUp(self):
+        self.canteen = Canteen.objects.create(name='Test Canteen')
+        self.warehouse = Warehouse.objects.create(name='Main', canteen=self.canteen)
+        self.ingredient = Ingredient.objects.create(
+            name='Mouka', unit='kg', base_unit='kg', recipe_unit='kg',
+            conversion_factor=Decimal('1.0'),
+        )
+        self.stock = StockItem.objects.create(
+            warehouse=self.warehouse, ingredient=self.ingredient,
+            quantity=Decimal('100.000'), price=Decimal('1.00'),
+        )
+        self.recipe = Recipe.objects.create(name='Chleba', base_portions=10)
+        RecipeIngredient.objects.create(
+            recipe=self.recipe, ingredient=self.ingredient,
+            quantity_per_portion=Decimal('1.000'),
+        )
+        self.menu_plan = MenuPlan.objects.create(
+            name='Test Menu', canteen=self.canteen,
+            date_from=date(2025, 9, 10), date_to=date(2025, 9, 10),
+        )
+        self.order = ProductionOrder.objects.create(
+            recipe=self.recipe, canteen=self.canteen,
+            menu_plan=self.menu_plan, date=date(2025, 9, 10),
+        )
+        ProductionOrderPortionVariant.objects.create(
+            production_order=self.order, portions=3, coefficient=Decimal('1.0'),
+        )
+        self.order.generate_picking_list()
+
+        self.document = PickingListDocument.objects.create(
+            name='Doc', canteen=self.canteen,
+            date_from=date(2025, 9, 10), date_to=date(2025, 9, 10),
+            created_by=User.objects.create_user(username='creator'),
+        )
+        # Přiřazení přes save() zablokuje plánované množství (reálný tok)
+        for item in PickingList.objects.filter(production_order=self.order):
+            item.document = self.document
+            item.save()
+
+        self.item = PickingList.objects.get(production_order=self.order)
+        # planned = 3 porce × 1 kg/porci
+        self.assertEqual(self.item.quantity_planned, Decimal('3.000'))
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
+
+        self.user = User.objects.create_superuser(username='admin', password='x')
+        self.client.force_login(self.user)
+
+    def _url(self):
+        return f'/production/vydejky/{self.document.id}/edit/'
+
+    def test_filled_quantity_issues_and_deducts(self):
+        """Vyplněné množství → COMPLETED, odblokuje a odečte ze skladu."""
+        response = self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '3',
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, PickingList.Status.COMPLETED)
+        self.assertEqual(self.item.quantity_actual, Decimal('3.000'))
+
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('97.000'))  # 100 - 3
+        self.assertEqual(self.stock.quantity_blocked, Decimal('0.000'))
+
+    def test_partial_fill_deducts_actual_and_releases_block(self):
+        """Vydané menší než plánované → odečte skutečné, blokace se uvolní celá."""
+        response = self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '2',
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.quantity_actual, Decimal('2.000'))
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('98.000'))  # 100 - 2
+        self.assertEqual(self.stock.quantity_blocked, Decimal('0.000'))
+
+    def test_empty_quantity_leaves_item_unchanged(self):
+        """Prázdné pole → beze změny: PENDING, blokace i sklad zůstanou."""
+        response = self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '',
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, PickingList.Status.PENDING)
+        self.assertIsNone(self.item.quantity_actual)
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('100.000'))
+        self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
+
+    def test_missing_field_leaves_item_unchanged(self):
+        """Pole vůbec neodeslané (jiná akce) → položka beze změny."""
+        response = self.client.post(self._url(), data={'cook': ''})
+        self.assertEqual(response.status_code, 302)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, PickingList.Status.PENDING)
+        self.assertIsNone(self.item.quantity_actual)
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity_blocked, Decimal('3.000'))
+
+    def test_delete_item_removes_and_unblocks(self):
+        """Koš → smaže položku a uvolní blokaci na skladu."""
+        item_id = self.item.id
+        response = self.client.post(self._url(), data={
+            f'delete_item_{item_id}': '1',
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.assertFalse(PickingList.objects.filter(id=item_id).exists())
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('100.000'))
+        self.assertEqual(self.stock.quantity_blocked, Decimal('0.000'))
+
+    def test_completed_item_not_reissued_on_resave(self):
+        """Vydaná položka se prázdným polem znovu neodečte (jednosměrný tok)."""
+        # vydáme
+        self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '3',
+        })
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('97.000'))
+
+        # opětovné uložení s prázdným polem nesmí sklad hnout
+        self.client.post(self._url(), data={
+            f'quantity_actual_item_{self.item.id}': '',
+        })
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.quantity, Decimal('97.000'))
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, PickingList.Status.COMPLETED)

--- a/apps/production/views.py
+++ b/apps/production/views.py
@@ -1134,8 +1134,8 @@ def picking_list_edit(request, document_id):
 
                 try:
                     quantity = Decimal(quantity_str.replace(',', '.'))
-                    if quantity < 0:
-                        raise ValueError('negative quantity')
+                    if quantity <= 0:
+                        raise ValueError('non-positive quantity')
 
                     # Vyplněné množství = vydat: přechod na COMPLETED v
                     # PickingList.save() odblokuje a odečte quantity_actual ze skladu.

--- a/apps/production/views.py
+++ b/apps/production/views.py
@@ -1056,7 +1056,9 @@ def picking_list_edit(request, document_id):
                 except (ValueError, IndexError):
                     continue
                 item = PickingList.objects.filter(
-                    id=del_item_id, document=document
+                    id=del_item_id,
+                    document=document,
+                    status=PickingList.Status.PENDING,
                 ).select_related('ingredient').first()
                 if item is None:
                     continue

--- a/apps/production/views.py
+++ b/apps/production/views.py
@@ -1039,10 +1039,35 @@ def picking_list_edit(request, document_id):
             updated_count = 0
             processed_count = 0
             added_count = 0
-            missing_quantity_fields = 0
+            deleted_count = 0
             item_validation_errors = 0
             completed_count_after_save = 0
             pending_count_after_save = 0
+
+            # Odebrání surovin košem: nepoužitá surovina se odstraní z výdejky.
+            # Musí proběhnout PŘED sestavením mapy položek níže, jinak by
+            # následné item.save() smazanou položku znovu vložilo.
+            # post_delete signál uvolní blokaci na skladu u PENDING položek.
+            for key in list(request.POST.keys()):
+                if not key.startswith('delete_item_'):
+                    continue
+                try:
+                    del_item_id = int(key.rsplit('_', 1)[1])
+                except (ValueError, IndexError):
+                    continue
+                item = PickingList.objects.filter(
+                    id=del_item_id, document=document
+                ).select_related('ingredient').first()
+                if item is None:
+                    continue
+                ingredient_name = item.ingredient.name
+                item.delete()
+                deleted_count += 1
+                messages.success(
+                    request,
+                    f'Surovina {ingredient_name} byla odebrána z výdejky.'
+                )
+
             # Re-fetch picking items fresh (nekombinujeme s pre-evaluovaným QS z locked check)
             # Načteme pouze položky s production_order (položky mimo jídla se needitují v této smyčce)
             picking_items_fresh = list(
@@ -1062,19 +1087,14 @@ def picking_list_edit(request, document_id):
                     )
 
             qty_keys_in_post = [k for k in request.POST.keys() if k.startswith('quantity_actual_item_')]
-            status_keys_in_post = [k for k in request.POST.keys() if k.startswith('status_item_')]
-            debug_qty_count = request.POST.get('debug_qty_count', 'missing')
             logger.info(
                 "picking_list_edit POST start: document_id=%s user_id=%s post_keys=%s item_count=%s "
-                "qty_fields_in_post=%s status_fields_in_post=%s debug_qty_count=%s "
-                "sample_post_keys=%s",
+                "qty_fields_in_post=%s sample_post_keys=%s",
                 document_id,
                 request.user.id,
                 len(request.POST.keys()),
                 len(picking_items_map),
                 len(qty_keys_in_post),
-                len(status_keys_in_post),
-                debug_qty_count,
                 list(request.POST.keys())[:10],
             )
 
@@ -1094,42 +1114,34 @@ def picking_list_edit(request, document_id):
                 document.cook = None
                 document.save(update_fields=['cook'])
             
+            from django.core.exceptions import ValidationError as DjangoValidationError
             for item_id, item in picking_items_map.items():
                 quantity_key = f'quantity_actual_item_{item_id}'
-                status_key = f'status_item_{item_id}'
-                had_quantity_in_post = quantity_key in request.POST
-
                 quantity_str = request.POST.get(quantity_key, '').strip()
-                # Prohlížeč může poslat prázdný řetězec pro pre-filled <input type="number">
-                # pokud hodnota selže HTML5 validaci (step/min) nebo pole vůbec neodešle.
+
+                # Prázdné pole = beze změny: položka zůstane PENDING a její
+                # plánované množství dál blokuje sklad. Z provozu se vyplňují
+                # jen skutečně vydané suroviny, ostatní se nechají prázdné.
                 if not quantity_str:
-                    if not had_quantity_in_post:
-                        missing_quantity_fields += 1
-                    if item.quantity_actual is not None:
-                        quantity_str = str(item.quantity_actual)
-                    else:
-                        quantity_str = str(item.quantity_planned)
+                    continue
+                # Již vydané položky se přes množství needitují – tok je
+                # jednosměrný (vyplnění = vydání). Oprava vydaného řádku se
+                # dělá odebráním košem a novým zadáním.
+                if item.status == PickingList.Status.COMPLETED:
+                    continue
 
                 try:
-                    from django.core.exceptions import ValidationError as DjangoValidationError
                     quantity = Decimal(quantity_str.replace(',', '.'))
-                    status = request.POST.get(status_key, PickingList.Status.PENDING)
-                    old_quantity_actual = item.quantity_actual
-                    old_status = item.status
+                    if quantity < 0:
+                        raise ValueError('negative quantity')
 
+                    # Vyplněné množství = vydat: přechod na COMPLETED v
+                    # PickingList.save() odblokuje a odečte quantity_actual ze skladu.
                     item.quantity_actual = quantity
-                    item.status = status
-
-                    has_changed = (old_quantity_actual != item.quantity_actual) or (old_status != item.status)
-                    if has_changed:
-                        item.save()
-                        updated_count += 1
-
+                    item.status = PickingList.Status.COMPLETED
+                    item.save()
+                    updated_count += 1
                     processed_count += 1
-                    if item.status == PickingList.Status.COMPLETED:
-                        completed_count_after_save += 1
-                    elif item.status == PickingList.Status.PENDING:
-                        pending_count_after_save += 1
                 except (ValueError, InvalidOperation):
                     item_validation_errors += 1
                     logger.warning(
@@ -1616,21 +1628,21 @@ def picking_list_edit(request, document_id):
             pending_count_after_save = sum(1 for s in all_items_stats if s == PickingList.Status.PENDING)
 
             logger.info(
-                "picking_list_edit POST summary: document_id=%s user_id=%s processed=%s updated=%s added=%s completed=%s pending=%s missing_quantity_fields=%s item_validation_errors=%s",
+                "picking_list_edit POST summary: document_id=%s user_id=%s processed=%s updated=%s added=%s deleted=%s completed=%s pending=%s item_validation_errors=%s",
                 document_id,
                 request.user.id,
                 processed_count,
                 updated_count,
                 added_count,
+                deleted_count,
                 completed_count_after_save,
                 pending_count_after_save,
-                missing_quantity_fields,
                 item_validation_errors,
             )
 
             messages.success(
                 request,
-                f'Aktualizováno {updated_count} položek. Vydáno: {completed_count_after_save}, čeká na vydání: {pending_count_after_save}.'
+                f'Vydáno {updated_count} položek. Celkem vydáno: {completed_count_after_save}, čeká na vydání: {pending_count_after_save}.'
             )
             return redirect('production:picking_list_edit', document_id=document_id)
         

--- a/templates/production/picking_list_edit.html
+++ b/templates/production/picking_list_edit.html
@@ -247,7 +247,7 @@
                          name="quantity_actual_item_{{ ing.item_id|unlocalize }}"
                          value=""
                          placeholder="{% if ing.status == 'COMPLETED' %}vydáno {{ ing.quantity_actual|floatformat:3 }}{% else %}plán {{ ing.quantity|floatformat:3 }}{% endif %}"
-                         {% if readonly_mode %}readonly{% endif %}>
+                         {% if readonly_mode or ing.status == 'COMPLETED' %}readonly{% endif %}>
                 </td>
                 <td class="text-center no-strike">
                   {% if ing.status == 'COMPLETED' %}

--- a/templates/production/picking_list_edit.html
+++ b/templates/production/picking_list_edit.html
@@ -380,7 +380,7 @@
                   {% endif %}
                 </td>
                 <td class="text-center">
-                  {% if not readonly_mode %}
+                  {% if not readonly_mode and item.status != 'COMPLETED' %}
                   <button type="submit" class="btn btn-sm btn-outline-danger btn-delete-item"
                           name="delete_item_{{ item.id|unlocalize }}" value="1"
                           data-ingredient="{{ item.ingredient.name }}"

--- a/templates/production/picking_list_edit.html
+++ b/templates/production/picking_list_edit.html
@@ -121,7 +121,7 @@
 
 <div class="alert alert-info mb-3">
   <i class="fas fa-info-circle me-2"></i>
-  <strong>Instrukce:</strong> Zadejte skutečně vydaná množství a zaškrtněte „Vydáno". Vydaný řádek se automaticky odečte ze skladu.
+  <strong>Instrukce:</strong> Zadejte skutečně vydaná množství. Vyplněný řádek se při uložení automaticky vydá a odečte ze skladu. Prázdné pole zůstane beze změny. Nepoužitou surovinu odeberte košem.
 </div>
 {% endif %}
 
@@ -199,13 +199,6 @@
           <small class="text-muted ms-2">{{ meal.portions }} porcí{% if meal.is_customized %} <i class="fas fa-star text-warning ms-1" title="Upravené jídlo"></i>{% endif %}</small>
           {% endif %}
         </span>
-        {% if not readonly_mode and meal.ingredients %}
-        <div class="d-flex gap-2">
-          <button type="button" class="btn btn-outline-success btn-sm meal-issue-all-btn" data-meal-id="{{ forloop.parentloop.counter }}_{{ forloop.counter }}">
-            <i class="fas fa-check-double me-1"></i>Vydat vše v jídle
-          </button>
-        </div>
-        {% endif %}
       </div>
       {% if meal.ingredients %}
       <div class="card-body p-0">
@@ -218,7 +211,7 @@
                 <th style="width:13%; text-align:center;">Plánováno</th>
                 <th style="width:7%; text-align:center;">Jedn.</th>
                 <th style="width:20%; text-align:center;">Skutečně vydáno</th>
-                <th style="width:25%; text-align:center;">Vydáno</th>
+                <th style="width:25%; text-align:center;">Akce</th>
               </tr>
             </thead>
             <tbody data-meal="{{ forloop.parentloop.counter }}_{{ forloop.counter }}">
@@ -252,20 +245,22 @@
                         inputmode="decimal"
                         class="form-control form-control-sm qty-actual"
                          name="quantity_actual_item_{{ ing.item_id|unlocalize }}"
-                         data-planned="{{ ing.quantity|unlocalize }}"
-                         value="{% if ing.quantity_actual is not None %}{{ ing.quantity_actual|unlocalize }}{% else %}{{ ing.quantity|unlocalize }}{% endif %}"
-                         placeholder="0.000"
+                         value=""
+                         placeholder="{% if ing.status == 'COMPLETED' %}vydáno {{ ing.quantity_actual|floatformat:3 }}{% else %}plán {{ ing.quantity|floatformat:3 }}{% endif %}"
                          {% if readonly_mode %}readonly{% endif %}>
                 </td>
                 <td class="text-center no-strike">
-                  <input type="checkbox"
-                         class="issued-checkbox issued-check"
-                         name="status_item_{{ ing.item_id|unlocalize }}"
-                         value="COMPLETED"
-                         id="issued_item_{{ ing.item_id|unlocalize }}"
-                         {% if ing.status == 'COMPLETED' %}checked{% endif %}
-                         {% if readonly_mode %}disabled{% endif %}>
-                  <label class="issued-label ms-1" for="issued_item_{{ ing.item_id|unlocalize }}">Vydáno</label>
+                  {% if ing.status == 'COMPLETED' %}
+                  <span class="badge bg-success me-2" title="Skutečně vydáno {{ ing.quantity_actual|floatformat:3 }} {{ ing.unit }}">Vydáno {{ ing.quantity_actual|floatformat:3 }}</span>
+                  {% endif %}
+                  {% if not readonly_mode %}
+                  <button type="submit" class="btn btn-sm btn-outline-danger btn-delete-item"
+                          name="delete_item_{{ ing.item_id|unlocalize }}" value="1"
+                          data-ingredient="{{ ing.name }}"
+                          title="Odebrat surovinu z výdejky">
+                    <i class="fas fa-trash"></i>
+                  </button>
+                  {% endif %}
                 </td>
               </tr>
               {% endfor %}
@@ -367,6 +362,7 @@
                 <th>Plánované množství</th>
                 <th>Skutečné množství</th>
                 <th>Stav</th>
+                <th class="text-center">Akce</th>
               </tr>
             </thead>
             <tbody>
@@ -381,6 +377,16 @@
                   <span class="badge bg-success">Vydáno</span>
                   {% else %}
                   <span class="badge bg-warning text-dark">Čeká</span>
+                  {% endif %}
+                </td>
+                <td class="text-center">
+                  {% if not readonly_mode %}
+                  <button type="submit" class="btn btn-sm btn-outline-danger btn-delete-item"
+                          name="delete_item_{{ item.id|unlocalize }}" value="1"
+                          data-ingredient="{{ item.ingredient.name }}"
+                          title="Odebrat surovinu z výdejky">
+                    <i class="fas fa-trash"></i>
+                  </button>
                   {% endif %}
                 </td>
               </tr>
@@ -439,13 +445,6 @@
     </a>
     {% if not readonly_mode %}
     <div class="d-flex align-items-center gap-2 flex-wrap">
-      <span class="text-muted small" id="issued-counter"></span>
-      <button type="button" class="btn btn-outline-secondary" id="btn-unissue-all">
-        <i class="fas fa-times me-2"></i>Odebrat vydání
-      </button>
-      <button type="button" class="btn btn-success" id="btn-issue-all">
-        <i class="fas fa-check-double me-2"></i>Vydat vše
-      </button>
       <button type="submit" class="btn btn-primary btn-lg">
         <i class="fas fa-save me-2"></i>Uložit změny
       </button>
@@ -462,9 +461,9 @@
           <i class="fas fa-question-circle me-2"></i>Co se stane po uložení?
         </h6>
         <ul class="mb-0">
-          <li>Položky se stavem <strong>"Čeká na vydání"</strong> – suroviny zůstanou zablokovány</li>
-          <li>Položky se stavem <strong>"Vydáno"</strong> – skutečné množství se automaticky odečte ze skladu</li>
-          <li>Ujistěte se, že máte vyplněno skutečné množství před změnou statusu na „Vydáno"</li>
+          <li><strong>Vyplněné</strong> skutečné množství – řádek se vydá a automaticky odečte ze skladu</li>
+          <li><strong>Prázdné</strong> pole – řádek zůstane beze změny, surovina zůstane zablokována</li>
+          <li>Nepoužitou surovinu odeberte <strong>košem</strong> – uvolní se blokace na skladu</li>
         </ul>
       </div>
     </div>
@@ -476,84 +475,25 @@
 <script>
 document.addEventListener('DOMContentLoaded', function () {
 
-    function setRowIssued(row, checked) {
-        const cb = row.querySelector('.issued-check');
-      if (!cb) return;
-        cb.checked = checked;
-        row.classList.toggle('row-issued', checked);
-    }
-
-    function updateCounter() {
-        const total = document.querySelectorAll('.issued-check').length;
-        const issued = document.querySelectorAll('.issued-check:checked').length;
-        const el = document.getElementById('issued-counter');
-        if (el) el.textContent = `Vydáno ${issued} / ${total} položek`;
-    }
-
-    // Checkbox → aktualizuje hidden field a styl řádku
-    document.querySelectorAll('.issued-check').forEach(function (cb) {
-        cb.addEventListener('change', function () {
-            const row = this.closest('tr');
-            setRowIssued(row, this.checked);
-            updateCounter();
-        });
-    });
-
-    // Změna množství → auto-zaškrtne (nebo odškrtne při 0)
+    // Normalizace množství (čárka → tečka) při psaní
     document.querySelectorAll('.qty-actual').forEach(function (input) {
         input.addEventListener('change', function () {
-            const row = this.closest('tr');
-        const normalized = (this.value || '').replace(',', '.').trim();
-        if (normalized !== this.value) {
-          this.value = normalized;
-        }
-        const val = Number(normalized);
-            if (!isNaN(val) && val > 0) {
-                setRowIssued(row, true);
-            } else if (!isNaN(val) && val === 0) {
-                setRowIssued(row, false);
+            const normalized = (this.value || '').replace(',', '.').trim();
+            if (normalized !== this.value) {
+                this.value = normalized;
             }
-            updateCounter();
         });
     });
 
-    // Tlačítko „Vydat vše v jídle" – per-meal
-    document.querySelectorAll('.meal-issue-all-btn').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-            const mealId = this.dataset.mealId;
-            const tbody = document.querySelector(`tbody[data-meal="${mealId}"]`);
-            if (!tbody) return;
-            tbody.querySelectorAll('tr[data-item-id]').forEach(function (row) {
-                setRowIssued(row, true);
-            });
-            updateCounter();
+    // Potvrzení před odebráním suroviny košem
+    document.querySelectorAll('.btn-delete-item').forEach(function (btn) {
+        btn.addEventListener('click', function (e) {
+            const name = this.dataset.ingredient || 'tuto surovinu';
+            if (!window.confirm(`Odebrat „${name}" z výdejky? Blokace na skladu se uvolní.`)) {
+                e.preventDefault();
+            }
         });
     });
-
-    // Tlačítko „Vydat vše"
-    const btnIssueAll = document.getElementById('btn-issue-all');
-    if (btnIssueAll) {
-        btnIssueAll.addEventListener('click', function () {
-            document.querySelectorAll('tr[data-item-id]').forEach(function (row) {
-                setRowIssued(row, true);
-            });
-            updateCounter();
-        });
-    }
-
-    // Tlačítko „Odebrat vydání"
-    const btnUnissueAll = document.getElementById('btn-unissue-all');
-    if (btnUnissueAll) {
-        btnUnissueAll.addEventListener('click', function () {
-            document.querySelectorAll('tr[data-item-id]').forEach(function (row) {
-                setRowIssued(row, false);
-            });
-            updateCounter();
-        });
-    }
-
-    // Počáteční stav counteru
-    updateCounter();
 
     // --- Toggle panelu pro přidávání surovin ---
     document.querySelectorAll('.btn-toggle-add-ingredient').forEach(function (btn) {
@@ -662,29 +602,13 @@ document.addEventListener('DOMContentLoaded', function () {
         container.appendChild(firstRow);
     });
 
-    // --- Submit handler: zaruč odeslání všech qty hodnot ---
+    // --- Submit handler: normalizace čárek na tečky před odesláním ---
     var form = document.getElementById('vydejka-form');
     if (form) {
         form.addEventListener('submit', function () {
-            var qtyInputs = form.querySelectorAll('.qty-actual');
-            qtyInputs.forEach(function (input) {
-                // Normalizuj čárku na tečku
-                var val = (input.value || '').replace(',', '.').trim();
-                // Pokud prázdné, doplň z data-planned
-                if (!val || isNaN(Number(val))) {
-                    val = (input.dataset.planned || '0').replace(',', '.');
-                }
-                input.value = val;
+            form.querySelectorAll('.qty-actual').forEach(function (input) {
+                input.value = (input.value || '').replace(',', '.').trim();
             });
-            // Přidej debug pole s počtem qty inputů (pro server log)
-            var dbg = form.querySelector('input[name="debug_qty_count"]');
-            if (!dbg) {
-                dbg = document.createElement('input');
-                dbg.type = 'hidden';
-                dbg.name = 'debug_qty_count';
-                form.appendChild(dbg);
-            }
-            dbg.value = qtyInputs.length;
         });
     }
 });

--- a/templates/production/picking_list_edit.html
+++ b/templates/production/picking_list_edit.html
@@ -253,7 +253,7 @@
                   {% if ing.status == 'COMPLETED' %}
                   <span class="badge bg-success me-2" title="Skutečně vydáno {{ ing.quantity_actual|floatformat:3 }} {{ ing.unit }}">Vydáno {{ ing.quantity_actual|floatformat:3 }}</span>
                   {% endif %}
-                  {% if not readonly_mode %}
+                  {% if not readonly_mode and ing.status != 'COMPLETED' %}
                   <button type="submit" class="btn btn-sm btn-outline-danger btn-delete-item"
                           name="delete_item_{{ ing.item_id|unlocalize }}" value="1"
                           data-ingredient="{{ ing.name }}"


### PR DESCRIPTION
Zjednodušení workflow evidence reálně vydaných surovin podle provozu:

- Pole skutečného množství jsou nově prázdná (placeholder ukazuje plán), z provozu se většina čísel přepisuje, předvyplnění nedávalo smysl.
- Vyplněné množství = vydat: řádek přejde na COMPLETED a odečte se ze skladu. Prázdné pole = beze změny (položka zůstane PENDING, blokace na skladu drží). Odstraněn tichý fallback na starou hodnotu.
- Odstraněn checkbox „Vydáno" a hromadná tlačítka (Vydat vše / Odebrat vydání / Vydat vše v jídle) – jednosměrný tok je bez nich přehlednější.
- Přidáno tlačítko koš pro odebrání nepoužité suroviny z výdejky; post_delete signál uvolní blokaci na skladu (komfortnější než 0+vydáno).

Testy: nový test_picking_edit_actuals (vyplněné/prázdné/koš/idempotence), test_meal_replacement helper posílá prázdná pole dle nové UX.

## Souhrn podle Sourcery

Přepracování workflow vychystávacího seznamu tak, aby se skutečná množství zadávala explicitně pro vyskladnění zásob, s volitelným mazáním nevyužitých ingrediencí a jasnějším jednosměrným zpracováním stavů.

Nové funkce:
- Umožnit odstranění nevyužitých ingrediencí z vychystávacího seznamu pomocí akce koše, která zároveň uvolní skladové rezervace.

Vylepšení:
- Změnit pole pro skutečné množství tak, aby byla na začátku prázdná a používala kontextové placeholdery místo předvyplněných plánovaných hodnot.
- Zjednodušit logiku vyskladnění tak, aby vyplnění skutečného množství položku rovnou dokončilo a odepsalo, zatímco prázdná nebo chybějící pole ponechají položky beze změny.
- Odstranit ovládací prvky pro vyskladnění/zpětné naskladnění na úrovni jednotlivých jídel i globální a také zaškrtávací políčko „vyskladněno“ ve prospěch lineárnějšího workflow po jednotlivých řádcích.
- Upravit zpracování formuláře a logování tak, aby odpovídaly novému chování množství a mazání a aby se zabránilo opětovnému zpracování již dokončených položek.

Testy:
- Přidat dedikovanou sadu testů pro nový workflow se skutečnými množstvími ve vychystávacím seznamu, pokrývající scénáře vyplněných, prázdných a chybějících hodnot, mazání a idempotentního opětovného uložení.
- Aktualizovat testy náhrady jídel tak, aby odpovídaly nové UX, kde jsou vstupy pro skutečná množství ve výchozím stavu prázdné.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rework the picking list workflow so that actual quantities are entered explicitly to issue stock, with optional deletion of unused ingredients and clearer one-way status handling.

New Features:
- Allow removing unused ingredients from a picking list via a trash action that also releases warehouse reservations.

Enhancements:
- Change actual quantity fields to start empty and use contextual placeholders instead of prefilled planned values.
- Simplify issuing logic so that filling an actual quantity directly completes and deducts the item, while empty or missing fields leave items unchanged.
- Remove per-meal and global issue/unissue controls and the issued checkbox in favor of a more linear, per-row workflow.
- Adjust form handling and logging to reflect the new quantity and deletion behavior and prevent re-processing already completed items.

Tests:
- Add a dedicated test suite for the new picking list actual-quantity workflow, covering filled, empty, missing, deletion, and idempotent re-save scenarios.
- Update meal replacement tests to align with the new UX where actual quantity inputs are empty by default.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct entry of actually issued quantities; filled rows are automatically marked completed and deducted from stock.
  * Added the ability to remove individual ingredients from a picking list with confirmation.
* **Bug Fixes**
  * Empty or missing quantity fields now leave items unchanged and preserve stock blocking.
  * Prevented completed items from being deducted again when saved.
  * Partial quantities now deduct only the amount actually issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->