### PR TITLE
Oprava bufet: 520 při importu velkého FiskalPRO exportu

### DIFF
--- a/apps/bufet/views.py
+++ b/apps/bufet/views.py
@@ -1,4 +1,5 @@
 import difflib
+import logging
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
@@ -16,6 +17,8 @@ from apps.inventory.models import StockWriteOff, StockWriteOffItem
 
 from .fiskalpro_parser import parse_bufet_file, parse_export_date
 from .models import BufetImport, BufetImportItem
+
+logger = logging.getLogger(__name__)
 
 NUMERIC_FIELDS = ('quantity',)
 MATCH_THRESHOLD = 0.45
@@ -241,6 +244,16 @@ def bufet_upload_step1(request):
         except ValueError as e:
             messages.error(request, f'Chyba při načítání souboru: {e}')
             return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
+        except Exception:
+            # Neočekávaná chyba parseru nesmí shodit worker (jinak Cloudflare
+            # vrátí 520 místo hlášky). Zalogujeme a ukážeme uživateli chybu.
+            logger.exception('Neočekávaná chyba při parsování bufet souboru %s', upload.name)
+            messages.error(
+                request,
+                'Soubor se nepodařilo zpracovat. Ověřte, že jde o XLSX export '
+                'z FiskalPRO ("Položky dokladů – kumulované").'
+            )
+            return render(request, 'bufet/bufet_upload_step1.html', {'warehouses': warehouses})
 
         if not items:
             messages.error(request, 'Soubor neobsahuje žádné prodané položky.')
@@ -279,6 +292,11 @@ def bufet_upload_step2(request):
         ingredient, score = _suggest_ingredient(item['name'], name_index)
         item['suggested_id'] = ingredient.id if ingredient else None
         item['suggested_name'] = ingredient.name if ingredient else None
+        # Popisek musí být totožný s value volby v <datalist> (viz šablona),
+        # aby JS podle napsaného textu dohledal id suroviny
+        item['suggested_label'] = (
+            f'{ingredient.name} ({ingredient.unit})' if ingredient else ''
+        )
         item['match_score'] = score
 
     try:

--- a/apps/bufet/views.py
+++ b/apps/bufet/views.py
@@ -293,9 +293,12 @@ def bufet_upload_step2(request):
         item['suggested_id'] = ingredient.id if ingredient else None
         item['suggested_name'] = ingredient.name if ingredient else None
         # Popisek musí být totožný s value volby v <datalist> (viz šablona),
-        # aby JS podle napsaného textu dohledal id suroviny
+        # aby JS podle napsaného textu dohledal id suroviny. Součástí je i id
+        # (#N), protože samotné name+unit nemusí být globálně jedinečné a jinak
+        # by se dvě stejně pojmenované suroviny namapovaly na tu nesprávnou.
         item['suggested_label'] = (
-            f'{ingredient.name} ({ingredient.unit})' if ingredient else ''
+            f'{ingredient.name} ({ingredient.unit}) #{ingredient.id}'
+            if ingredient else ''
         )
         item['match_score'] = score
 

--- a/templates/bufet/bufet_upload_step2.html
+++ b/templates/bufet/bufet_upload_step2.html
@@ -96,17 +96,14 @@
           <td class="fw-bold">{{ item.quantity }} {{ item.unit }}</td>
           <td class="small text-muted">{{ item.establishments|default:"–" }}</td>
           <td>
-            <select name="ingredient_{{ forloop.counter0 }}"
-                    class="form-select form-select-sm ingredient-select ingredient-field"
-                    data-idx="{{ forloop.counter0 }}">
-              <option value="">– nevybráno –</option>
-              {% for ing in all_ingredients %}
-              <option value="{{ ing.id }}"
-                {% if ing.id == item.suggested_id %}selected{% endif %}>
-                {{ ing.name }} ({{ ing.unit }})
-              </option>
-              {% endfor %}
-            </select>
+            <input type="text" list="ingredient-options"
+                   class="form-control form-control-sm ingredient-select ingredient-input"
+                   data-idx="{{ forloop.counter0 }}"
+                   value="{{ item.suggested_label }}"
+                   placeholder="– nevybráno –" autocomplete="off">
+            <input type="hidden" name="ingredient_{{ forloop.counter0 }}"
+                   class="ingredient-field" data-idx="{{ forloop.counter0 }}"
+                   value="{{ item.suggested_id|default:'' }}">
           </td>
           <td class="text-center">
             {% if item.match_score >= 70 %}
@@ -128,6 +125,16 @@
     </table>
   </div>
 
+  <!-- Seznam surovin renderovaný JEN JEDNOU pro všechny řádky. Dřív měl každý
+       řádek vlastní <select> se všemi surovinami (položky × suroviny options),
+       což u velkých importů nafouklo HTML na desítky MB a shazovalo worker
+       (chyba 520). Sdílený <datalist> to srazí na jeden seznam. -->
+  <datalist id="ingredient-options">
+    {% for ing in all_ingredients %}
+    <option data-id="{{ ing.id }}" value="{{ ing.name }} ({{ ing.unit }})"></option>
+    {% endfor %}
+  </datalist>
+
   <div class="d-flex justify-content-end mt-3">
     <button type="submit" class="btn btn-success btn-lg">
       <i class="fas fa-check me-2"></i>Potvrdit import a odepsat ze skladu
@@ -142,6 +149,23 @@ document.addEventListener('DOMContentLoaded', function () {
   const rows = document.querySelectorAll('.item-row');
   const mappedEl = document.getElementById('mapped-count');
   const skippedEl = document.getElementById('skipped-count');
+
+  // Mapa napsaný text (value volby) -> id suroviny, sestavená ze sdíleného
+  // <datalist>. Umožní z textového inputu dohledat id do skrytého pole.
+  const labelToId = {};
+  document.querySelectorAll('#ingredient-options option').forEach(function (opt) {
+    labelToId[opt.value] = opt.dataset.id;
+  });
+
+  // Při změně textu dohledáme id; neznámý/prázdný text = surovina nevybrána
+  document.querySelectorAll('.ingredient-input').forEach(function (input) {
+    input.addEventListener('input', function () {
+      const idx = this.dataset.idx;
+      const hidden = document.querySelector('.ingredient-field[data-idx="' + idx + '"]');
+      hidden.value = labelToId[this.value.trim()] || '';
+      updateCounters();
+    });
+  });
 
   function updateCounters() {
     let mapped = 0, skipped = 0;

--- a/templates/bufet/bufet_upload_step2.html
+++ b/templates/bufet/bufet_upload_step2.html
@@ -131,7 +131,9 @@
        (chyba 520). Sdílený <datalist> to srazí na jeden seznam. -->
   <datalist id="ingredient-options">
     {% for ing in all_ingredients %}
-    <option data-id="{{ ing.id }}" value="{{ ing.name }} ({{ ing.unit }})"></option>
+    {# #id v popisku odliší suroviny se shodným name+unit (jinak by se
+       namapovaly na tu nesprávnou) #}
+    <option data-id="{{ ing.id }}" value="{{ ing.name }} ({{ ing.unit }}) #{{ ing.id }}"></option>
     {% endfor %}
   </datalist>
 
@@ -157,11 +159,11 @@ document.addEventListener('DOMContentLoaded', function () {
     labelToId[opt.value] = opt.dataset.id;
   });
 
-  // Při změně textu dohledáme id; neznámý/prázdný text = surovina nevybrána
+  // Při změně textu dohledáme id; neznámý/prázdný text = surovina nevybrána.
+  // Skryté pole je ve stejné buňce (stabilní vztah v DOM, ne lookup přes idx).
   document.querySelectorAll('.ingredient-input').forEach(function (input) {
+    const hidden = input.closest('td').querySelector('.ingredient-field');
     input.addEventListener('input', function () {
-      const idx = this.dataset.idx;
-      const hidden = document.querySelector('.ingredient-field[data-idx="' + idx + '"]');
       hidden.value = labelToId[this.value.trim()] || '';
       updateCounters();
     });


### PR DESCRIPTION
Krok 2 párování renderoval pro každý řádek importu vlastní <select> se všemi surovinami (položky × suroviny options). U reálného exportu (346 položek, 457 surovin = 158k <option>) narostlo HTML na ~20 MB; render a přenos na produkci přetekly worker timeout → Cloudflare 520.

- Šablona: seznam surovin renderován jen jednou jako sdílený <datalist>, per řádek textový input + hidden input s id; JS mapuje napsaný text na id. Submit (ingredient_{idx}=id) i krok 3 beze změny. HTML 20,7 MB → 0,47 MB, render 1,0s → 0,03s.
- View: doplněn suggested_label (musí odpovídat value volby v datalistu).
- View krok 1: parser obalen i pro neočekávané výjimky (nejen ValueError)
  + log, aby chyba parseru neshodila worker (520) místo hlášky.

## Summary by Sourcery

Přepracování mapování ingrediencí při bufet importu, aby se zabránilo vykreslování select boxů s kompletním seznamem ingrediencí v každém řádku, a zpolehlivění počátečního kroku nahrávání proti chybám parseru, které dříve způsobovaly chyby 520.

New Features:
- Použití společného selektoru ingrediencí založeného na `datalist` s textovým vstupem a skrytými poli pro ID pro všechny řádky bufet importu, čímž se výrazně zmenší velikost HTML a zkrátí doba vykreslování u velkých exportů z FiskalPRO.

Bug Fixes:
- Zabránění chybám Cloudflare 520 během parsování bufet souboru zachycením neočekávaných výjimek parseru, jejich zalogováním a zobrazením uživatelsky srozumitelné chybové zprávy místo pádu workeru.

Enhancements:
- Přidání `suggested_label` k položkám bufet importu, který odpovídá zobrazovanému textu ingredience používanému ve sdíleném `datalist`, aby klientská logika mapování z labelu na ID ingredience fungovala spolehlivě.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Redesign bufet import ingredient mapping to avoid rendering per-row select boxes with all ingredients, and harden the initial upload step against parser failures that previously caused 520 errors.

New Features:
- Use a shared datalist-based ingredient selector with text input and hidden id fields for all bufet import rows to significantly reduce HTML size and render time on large FiskalPRO exports.

Bug Fixes:
- Prevent Cloudflare 520 errors during bufet file parsing by catching unexpected parser exceptions, logging them, and surfacing a user-facing error message instead of crashing the worker.

Enhancements:
- Include a suggested_label on bufet import items that matches the ingredient display text used in the shared datalist so client-side mapping from label to ingredient id works reliably.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ingredient matching during buffet item import with searchable suggestions.
  * Added clearer ingredient labels showing both name and unit.
  * Preserved selected ingredient IDs automatically when choosing suggestions.

* **Bug Fixes**
  * Upload failures now display a helpful message instead of crashing the process.
  * Unexpected file-processing errors are handled safely during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->